### PR TITLE
Properly use EVAL-WHEN to compile with Bazel

### DIFF
--- a/src/common.lisp
+++ b/src/common.lisp
@@ -10,7 +10,7 @@
 
 ;;; Custom variables
 
-(eval-when (:compile-toplevel :load-toplevel)
+(eval-when (:compile-toplevel :load-toplevel :execute)
 
 (defvar *custom-vars* nil)
 
@@ -44,7 +44,7 @@
 )
 
 (defmacro define-custom-var ((key name) &rest other-args)
-  `(eval-when (:compile-toplevel :load-toplevel)
+  `(eval-when (:compile-toplevel :load-toplevel :execute)
      (progn (pushnew '(,name . ,key) *custom-vars* :test #'equal)
             (defvar ,name ,@other-args))))
 

--- a/src/decoder-args.lisp
+++ b/src/decoder-args.lisp
@@ -2,7 +2,7 @@
 
 ;;; Custom variables
 
-(eval-when (:compile-toplevel :load-toplevel)
+(eval-when (:compile-toplevel :load-toplevel :execute)
 
 (defvar *custom-vars* nil)
 
@@ -21,7 +21,7 @@
 )
 
 (defmacro define-custom-var ((key name) &rest other-args)
-  `(eval-when (:compile-toplevel :load-toplevel)
+  `(eval-when (:compile-toplevel :load-toplevel :execute)
      (progn (pushnew '(,name . ,key) *custom-vars* :test #'equal)
             (defvar ,name ,@other-args))))
 

--- a/src/encoder.lisp
+++ b/src/encoder.lisp
@@ -390,7 +390,7 @@ characters in string S to STREAM."
             (destructuring-bind (esc . (width . radix)) special
               (format stream "\\~C~V,V,'0R" esc radix width code)))))
 
-(eval-when (:compile-toplevel)
+(eval-when (:compile-toplevel :execute)
     (if (subtypep 'long-float 'single-float)
         ;; only one float type
         (pushnew :cl-json-only-one-float-type *features*)

--- a/src/objects.lisp
+++ b/src/objects.lisp
@@ -53,12 +53,13 @@ registered in the superclass."
   (declare (ignore superclass subclass))
   (values))
 
-(defmethod validate-superclass ((class fluid-class)
-                                (superclass standard-class))
-  "Any fluid class is also a standard class."
-  t)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+ (defmethod validate-superclass ((class fluid-class)
+                                 (superclass standard-class))
+   "Any fluid class is also a standard class."
+   t))
 
-(finalize-inheritance
+(eval-when (:compile-toplevel :load-toplevel :execute)
  (defclass fluid-object (standard-object) ()
    (:documentation "Any instance of a fluid class.")
    (:metaclass fluid-class)))


### PR DESCRIPTION
1- EVAL-WHEN needs to always include :execute
   See the discussion at http://fare.livejournal.com/146698.html
2- Use EVAL-WHEN around some key metaclass definitions.
