### PR TITLE
Character type *accumulator* stream

### DIFF
--- a/src/decoder.lisp
+++ b/src/decoder.lisp
@@ -516,7 +516,7 @@ list."
 
 (defun init-string-stream-accumulator ()
   "Initialize a string-stream accumulator."
-  (setq *accumulator* (make-string-output-stream)))
+  (setq *accumulator* (make-string-output-stream :element-type 'character)))
 
 (defun string-stream-accumulator-add (char)
   "Add CHAR to the end of the string-stream accumulator."


### PR DESCRIPTION
When decoding strings containing non base-char characters in Lispworks 7.1, the function `string-stream-accumulator-add` gave an error because the `*accumulator*` stream was initialised as containing base-chars, instead of characters. 

```
(defparameter *output-stream* (make-string-output-stream))
(write-char #\’ *output-stream*)
```

This can be solved by setting the element-type explicitly to character when initializing the stream.

```
(defparameter *output-stream* (make-string-output-stream :element-type 'character))
(write-char #\’ *output-stream*)
```
