### PR TITLE
Fix encoding and decoding of non-BMP characters

### DIFF
--- a/cl-json.asd
+++ b/cl-json.asd
@@ -38,7 +38,7 @@
                              (:file "json-rpc" :depends-on ("package" "common" "utils" "encoder" "decoder"))))))
 
 (defsystem :cl-json.test
-  :depends-on (:cl-json :fiveam )
+  :depends-on (:cl-json :cl-unicode :fiveam)
   ;; newer ASDF versions have this implicitly, but I know of no good way to detect this. [2010/01/02:rpg]
   :in-order-to ((test-op (load-op "cl-json.test")))
   :components ((:module :t

--- a/src/common.lisp
+++ b/src/common.lisp
@@ -68,6 +68,24 @@
 Strings.  If nil, translate any such sequence to the char after
 slash.")
 
+(defun bmp-code-p (code)
+  (< code #x10000))
+
+(defun high-surrogate-code-p (code)
+  (<= #xD800 code #xDBFF))
+
+(defun low-surrogate-code-p (code)
+  (<= #xDC00 code #xDFFF))
+
+(defun surrogate-pair (code)
+  (let ((reduced (- code #x10000)))
+    (cons (+ #xD800 (ldb (byte 10 10) reduced))
+          (+ #xDC00 (ldb (byte 10  0) reduced)))))
+
+(defun surrogate-pair-to-code (pair)
+  (+ (+ (ash (- (car pair) #xD800) 10)
+        (- (cdr pair) #xDC00))
+     #x10000))
 
 ;;; Symbols
 

--- a/src/encoder.lisp
+++ b/src/encoder.lisp
@@ -388,7 +388,13 @@ characters in string S to STREAM."
      else
        do (let ((special '#.(rassoc-if #'consp +json-lisp-escaped-chars+)))
             (destructuring-bind (esc . (width . radix)) special
-              (format stream "\\~C~V,V,'0R" esc radix width code)))))
+              (flet ((write-code (code)
+                       (format stream "\\~C~V,V,'0R" esc radix width code)))
+                (if (bmp-code-p code)
+                    (write-code code)
+                    (let ((pair (surrogate-pair code)))
+                      (write-code (car pair))
+                      (write-code (cdr pair)))))))))
 
 (eval-when (:compile-toplevel)
     (if (subtypep 'long-float 'single-float)

--- a/t/testdecoder.lisp
+++ b/t/testdecoder.lisp
@@ -411,3 +411,18 @@ safe-symbols-parsing function here for a cure."
         (is (equal (symbol-package (first-bound-slot-name x))
                    (find-package :keyword)))))))
 
+(test non-ascii-char-decoding
+  (is (equal `((:foo . ,(string (cl-unicode:character-named "Copyright Sign"))))
+             (with-decoder-simple-list-semantics
+               (decode-json-from-string "{\"foo\":\"\\u00A9\"}")))))
+
+(test non-bmp-char-decoding
+  (is (equal `((:foo . ,(string (cl-unicode:character-named "Grinning Face"))))
+             (with-decoder-simple-list-semantics
+               (decode-json-from-string "{\"foo\":\"\\uD83D\\uDE00\"}"))))
+  (signals error
+    (with-decoder-simple-list-semantics
+      (decode-json-from-string "{\"foo\":\"\\uD83Dabc\"}")))
+  (signals error
+    (with-decoder-simple-list-semantics
+      (decode-json-from-string "{\"foo\":\"\\uD83D\\xDE00\"}"))))

--- a/t/testencoder.lisp
+++ b/t/testencoder.lisp
@@ -470,3 +470,12 @@
       (is (string= json-bar
 "{\"method\":\"fooBarCheck\",\"id\":0,\"params\":{\"bar\":{\"bar\":true},\"isFoo\":false,\"isBar\":true}}")))))
 
+(test non-ascii-char-encoding
+  (is (string= "{\"foo\":\"\\u00A9\"}"
+               (with-explicit-encoder
+                 (json:encode-json-to-string (list :object "foo" (string (cl-unicode:character-named "Copyright Sign"))))))))
+
+(test non-bmp-char-encoding
+  (is (string= "{\"foo\":\"\\uD83D\\uDE00\"}"
+               (with-explicit-encoder
+                 (json:encode-json-to-string (list :object "foo" (string (cl-unicode:character-named "Grinning Face"))))))))


### PR DESCRIPTION
This PR corrects handling of unicode characters not in the basic multilingual plane. The JSON spec requires these to be split into surrogate pairs.